### PR TITLE
Removed redundant import from html

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -6,11 +6,7 @@
     <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.1.1/jquery.min.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/crossfilter/1.3.12/crossfilter.js" integrity="sha256-cIcPwh2GcosI6bCl+ZAZt2j0Sk1QfgQ1ejEpjYOfa8g="
         crossorigin="anonymous"></script>
-
-
-
     <script src="https://unpkg.com/a-framedc@1.0.7/dist/aframedc.min.js"></script>
-    <script src="./demoBarchart3d.js"></script>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
     <meta name="theme-color" content="#000000">


### PR DESCRIPTION
After running `yarn build` make the following edits to `build/index.html`:

replace `"/s/jvlrl98xw3/static/js/main.464f06df.js"` with `"/static/js/main.464f06df.js"`
replace `/s/jvlrl98xw3/favicon.ico"` with `/favicon.ico"`

